### PR TITLE
Fix joystick script

### DIFF
--- a/Summer Project/Assets/Prefabs/Joystick.prefab
+++ b/Summer Project/Assets/Prefabs/Joystick.prefab
@@ -35,11 +35,11 @@ RectTransform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 400, y: 450}
-  m_Pivot: {x: 0.000000014901161, y: 0.49999994}
+  m_SizeDelta: {x: 300, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1918259262048002427
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -90,11 +90,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 824d58310176e499791601ff956d8a80, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  StickSensitive: 0.3
-  StickMoveLimit: 10
-  axisDirection: 0
-  BackgroundObject: {fileID: 1918259262473602705}
-  HandleObject: {fileID: 1918259263156083938}
+  StickSensitive: 1
+  StickMoveLimit: 0
+  AxisDirection: 0
+  BackgroundRect: {fileID: 1918259262473602706}
+  HandleRect: {fileID: 1918259263156083939}
   CircleBackground: {fileID: 21300000, guid: 2c28074fd63504be1b4ae6a0627af956, type: 3}
   HorizontalBackground: {fileID: 21300000, guid: 1b3382d8f8ede428cab022d8e557f792, type: 3}
   VerticalBackground: {fileID: 21300000, guid: 007de674b01bf4919bf3f411d31d7152, type: 3}
@@ -132,10 +132,10 @@ RectTransform:
   m_Father: {fileID: 1918259262048002424}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 49.999996, y: 50}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1918259262473602708
 CanvasRenderer:
@@ -211,7 +211,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 32, y: 32}
+  m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1918259263156083941
 CanvasRenderer:

--- a/Summer Project/Assets/Scripts/Joystick.cs
+++ b/Summer Project/Assets/Scripts/Joystick.cs
@@ -44,8 +44,10 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
 
     /// <summery>
     /// Stick movement limit
+    /// (0 : Circle border, -1 : Inside the circle, +1 : Outside the circle)
     /// </summery>
-    public int StickMoveLimit = 10;
+    [Range(-3.0f, 3.0f)]
+    public float StickMoveLimit = 0;
 
     /// <summary>
     /// Stick movement axix direction
@@ -140,7 +142,8 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
             if (position.magnitude > 1.0f) position = position.normalized;
 
             // Set handle anchoredPosition
-            handleRectTransform.anchoredPosition = position * (backgroundRectTransform.position / StickMoveLimit);
+            Vector3 moveLimit = (BackgroundRect.sizeDelta + (HandleRect.sizeDelta * StickMoveLimit)) / 2;
+            HandleRect.anchoredPosition = position * moveLimit;
         }
     }
 }

--- a/Summer Project/Assets/Scripts/Joystick.cs
+++ b/Summer Project/Assets/Scripts/Joystick.cs
@@ -52,9 +52,9 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
     [SerializeField] private JoysticAxis axisDirection;
 
     // Joystick parts
-    [Header("Objects")]
-    public GameObject BackgroundObject;
-    public GameObject HandleObject;
+    [Header("Rects")]
+    public RectTransform BackgroundRect;
+    public RectTransform HandleRect;
 
     // When AxisDircetion changes, the background sprites changes.
     // If the sprite is null, it is not changed.
@@ -88,15 +88,15 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
 
     private Vector2 position = Vector2.zero;
     private Vector2 lastPosition;
-    private RectTransform backgroundRectTransform;
-    private RectTransform handleRectTransform;
+
+
+
 
     private void Awake()
     {
-        backgroundRectTransform = GetComponent<RectTransform>();
-        handleRectTransform = HandleObject.GetComponent<RectTransform>();
+    }
 
-        SetAxisDirection(axisDirection);
+
     }
 
     private void SetAxisDirection(JoysticAxis value)
@@ -131,16 +131,16 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
         position = Vector2.zero;
         
         // Reset handle anchoredPosition
-        handleRectTransform.anchoredPosition = Vector2.zero;
+        HandleRect.anchoredPosition = Vector2.zero;
     }
 
     public virtual void OnDrag(PointerEventData eventData)
     {
         if (RectTransformUtility.ScreenPointToLocalPointInRectangle(
-            backgroundRectTransform, eventData.position, eventData.pressEventCamera, out position))
+            BackgroundRect, eventData.position, eventData.pressEventCamera, out position))
         {
             // Set position
-            position /= backgroundRectTransform.sizeDelta * StickSensitive;
+            position /= BackgroundRect.sizeDelta * StickSensitive;
 
             // Check AxisDirection
             if (axisDirection == JoysticAxis.Horizontal) position.y = 0;

--- a/Summer Project/Assets/Scripts/Joystick.cs
+++ b/Summer Project/Assets/Scripts/Joystick.cs
@@ -33,6 +33,8 @@ public enum JoysticAxis
 /// </example>
 public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IDragHandler
 {
+    [Header("Stick Move")]
+
     /// <summary>
     /// Stick sensitive value (range from 0 to 1)
     /// Do not enter a value that exceeds the range.

--- a/Summer Project/Assets/Scripts/Joystick.cs
+++ b/Summer Project/Assets/Scripts/Joystick.cs
@@ -39,7 +39,8 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
     /// Stick sensitive value (range from 0 to 1)
     /// Do not enter a value that exceeds the range.
     /// </summary>
-    [Range(0, 1)] public float StickSensitive = 1;
+    [Range(0.0f, 1.0f)]
+    public float StickSensitive = 1;
 
     /// <summery>
     /// Stick movement limit

--- a/Summer Project/Assets/Scripts/Joystick.cs
+++ b/Summer Project/Assets/Scripts/Joystick.cs
@@ -47,9 +47,12 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
     /// </summery>
     public int StickMoveLimit = 10;
 
-    // Stick movement axix direction
-    // Restricting movement horizontal or vertically.
-    [SerializeField] private JoysticAxis axisDirection;
+    /// <summary>
+    /// Stick movement axix direction
+    /// Restricting movement horizontal or vertically
+    /// </summary>
+    [Header("Stick Axis Direction")]
+    public JoysticAxis AxisDirection;
 
     // Joystick parts
     [Header("Rects")]
@@ -62,14 +65,6 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
     public Sprite CircleBackground;
     public Sprite HorizontalBackground;
     public Sprite VerticalBackground;
-
-    /// <summary>
-    /// Restricting movement horizontal or vertically
-    /// </summary>
-    public JoysticAxis AxisDirection {
-        set { SetAxisDirection(value); }
-        get { return axisDirection; }
-    }
 
     /// <summary>
     /// The stick position
@@ -88,35 +83,30 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
 
     private Vector2 position = Vector2.zero;
     private Vector2 lastPosition;
-
-
-
+    private Image backgroundImage;
 
     private void Awake()
     {
+        backgroundImage = BackgroundRect.GetComponent<Image>();
     }
 
-
-    }
-
-    private void SetAxisDirection(JoysticAxis value)
+    private void Update()
     {
-        // Set an AxisDirection
-        axisDirection = value;
+        SetJoystickSprite();
+    }
 
-        // Get an Image instance
-        Image backgroundImage = BackgroundObject.GetComponent<Image>();
-
+    private void SetJoystickSprite()
+    {
         // Bath
-        if (CircleBackground != null && axisDirection == JoysticAxis.Both)
+        if (CircleBackground != null && AxisDirection == JoysticAxis.Both)
             backgroundImage.sprite = CircleBackground;
 
         // Horizontal
-        else if (HorizontalBackground != null && axisDirection == JoysticAxis.Horizontal)
+        else if (HorizontalBackground != null && AxisDirection == JoysticAxis.Horizontal)
             backgroundImage.sprite = HorizontalBackground;
 
         // Vertical
-        else if (VerticalBackground != null && axisDirection == JoysticAxis.Vertical)
+        else if (VerticalBackground != null && AxisDirection == JoysticAxis.Vertical)
             backgroundImage.sprite = VerticalBackground;
     }
 
@@ -133,7 +123,7 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
         // Reset handle anchoredPosition
         HandleRect.anchoredPosition = Vector2.zero;
     }
-
+ 
     public virtual void OnDrag(PointerEventData eventData)
     {
         if (RectTransformUtility.ScreenPointToLocalPointInRectangle(
@@ -143,8 +133,8 @@ public class Joystick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, I
             position /= BackgroundRect.sizeDelta * StickSensitive;
 
             // Check AxisDirection
-            if (axisDirection == JoysticAxis.Horizontal) position.y = 0;
-            else if (axisDirection == JoysticAxis.Vertical) position.x = 0;
+            if (AxisDirection == JoysticAxis.Horizontal) position.y = 0;
+            else if (AxisDirection == JoysticAxis.Vertical) position.x = 0;
 
             // When position is too far, normalize position magnitude to 1
             if (position.magnitude > 1.0f) position = position.normalized;


### PR DESCRIPTION
## Changes
- [x] 조이스틱이 타원형으로 회전하던 버그를 좌표 계산 공식을 수정하여 해결했습니다.
  - `StickMoveLimit`값이 `0`인 경우 원의 경계선에, `양수`인 경우 원의 바깥쪽으로, `음수`인 경우 원의 안쪽으로 `Handle`이 위치합니다.
  - `StickMoveLimit`값이 `-1`, `+1`일 때 `Handle`이 정확하게 원의 경계선과 붙어 있도록 했습니다.
- [x] 조이스틱 Prefab 역시 수정된 스크립트가 적용되었습니다.
- [x] 스크립트의 일부 주석과 Header 이름을 수정했습니다.
- [x] `AxisDirection` 값을 실시간으로 반영할 수 있도록 Update 함수에 관련 코드를 추가하고 접근제어자를 `public`으로 수정했습니다.

## 확인 사항
- 조이스틱 Prefab을 Scene에 배치하고 `StickMoveLimit` 값을 수정하면서 잘 작동되는지 확인해 주세요.
- 조이스틱 안에 `Background`와 `Handle`의 가로, 세로 값이 변경되어도 잘 작동되어야 합니다.

## 참고 이미지
- 조이스틱 Inspector 화면
<img width="604" alt="스크린샷 2022-09-11 오후 4 13 50" src="https://user-images.githubusercontent.com/31740224/189516493-4651519a-00ec-4723-8ccd-473f4e8c9286.png">

- 조이스틱 Background, Handle 가로, 세로 크기 조절 방법
(RectTransform의 Width, Height 값을 조절해 주시면 됩니다.)
<img width="1035" alt="스크린샷 2022-09-11 오후 4 15 48" src="https://user-images.githubusercontent.com/31740224/189516551-e7b60248-0a73-4af0-9fee-a4d82313c1d6.png">
